### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "vueisotope",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "vue isotope for directive",
-  "main": "src/vue_isotope.js",
+  "main": "dist/vue_isotope.min.js",
   "files": [
+    "dist/vue_isotope.min.js",
     "src/vue_isotope.js"
   ],
   "keywords": [


### PR DESCRIPTION
Specify the file after the build to the "main" field. Because users are not necessarily using the module loader and transformer compiler with the same settings as the author.

my uglify is ignore /node_modules, so show error at
https://github.com/David-Desmaisons/Vue.Isotope/blob/861683cdc246a55dfd2b3caa8ab753b01aa55b94/src/vue_isotope.js#L35

```
SyntaxError: Unexpected token punc «,», expected punc «:»
```