### PR TITLE
check for node before adding class

### DIFF
--- a/src/vue_isotope.js
+++ b/src/vue_isotope.js
@@ -2,8 +2,10 @@
   function buildVueIsotope(_, Isotope){
 
     function addClass(node, classValue){
-      const initValue = (node.data.staticClass === undefined) ? "" : node.data.staticClass + " "
-      node.data.staticClass = initValue + classValue
+      if(node.data){
+        const initValue = (node.data.staticClass === undefined) ? "" : node.data.staticClass + " "
+        node.data.staticClass = initValue + classValue
+      }
     }
 
     function getItemVm(elmt){


### PR DESCRIPTION
Vue-isotope fails to initialize with the error `TypeError: Cannot read property 'staticClass' of undefined` if items within the `<isotope>` component are filtered with `v-if` unless there is a check for the items presence before adding the class. 